### PR TITLE
Improve performance in loading homework and file lists

### DIFF
--- a/TeamsAssignmentExplorer/DirAndFileScanner.cs
+++ b/TeamsAssignmentExplorer/DirAndFileScanner.cs
@@ -121,20 +121,12 @@ namespace TeamsAssignmentExplorer
 
                             foreach (string versionDir in Directory.EnumerateDirectories(hwPath))
                             {
-                                foreach (string file in Directory.GetFiles(versionDir))
-                                {
-                                    // Strip base path from the filename.
-                                    submittedFiles.Add(file.Substring(basePath.Length + 1));
-                                }
+                                foreach (string file in Directory.EnumerateFiles(versionDir))
+                                    submittedFiles.Add(StripBasePath(file, basePath));
                             }
 
-                            { // Scope
-                                foreach (string file in Directory.GetFiles(hwPath))
-                                {
-                                    // Strip base path from the filename.
-                                    workingFiles.Add(file.Substring(basePath.Length + 1));
-                                }
-                            }
+                            foreach (string file in Directory.EnumerateFiles(hwPath))
+                                workingFiles.Add(StripBasePath(file, basePath));
                         });
                 }
             }
@@ -155,6 +147,16 @@ namespace TeamsAssignmentExplorer
                 SubmittedFiles = submittedFilesSorted,
                 WorkingFiles = workingFilesSorted
             };
+        }
+
+        private static string StripBasePath(string path, string basePath)
+        {
+            if (!path.StartsWith(basePath))
+                return path;
+
+            if (basePath.Last() == Path.DirectorySeparatorChar)
+                return path.Substring(basePath.Length);
+            return path.Substring(basePath.Length + 1);
         }
     }
 }

--- a/TeamsAssignmentExplorer/DirAndFileScanner.cs
+++ b/TeamsAssignmentExplorer/DirAndFileScanner.cs
@@ -105,9 +105,11 @@ namespace TeamsAssignmentExplorer
             var workingFiles = new List<string>();
             try
             {
-                foreach (string submittedOrWorkingFilesDir in Directory.EnumerateDirectories(basePath))
+                foreach (string submittedOrWorkingFilesDir in
+                         Directory.EnumerateDirectories(basePath))
                 {
-                    foreach (string userDir in Directory.EnumerateDirectories(submittedOrWorkingFilesDir))
+                    foreach (string userDir in
+                             Directory.EnumerateDirectories(submittedOrWorkingFilesDir))
                     {
                         string hwPath = Path.Combine(userDir, homework);
                         if (!Directory.Exists(hwPath))

--- a/TeamsAssignmentExplorer/DirAndFileScanner.cs
+++ b/TeamsAssignmentExplorer/DirAndFileScanner.cs
@@ -41,6 +41,11 @@ namespace TeamsAssignmentExplorer
 
         public static List<HomeworkItem> GetHomeworkList(string basePath)
         {
+#if DEBUG 
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+#endif
+
             // Glob [basePath]/Submitted files/[user]/[homework] and
             // [basePath]/Working files/[user]/[homework]
             var homeworkMap = new SortedDictionary<string, bool>();
@@ -65,6 +70,12 @@ namespace TeamsAssignmentExplorer
                 }
             }
             catch (Exception) { /* Do nothing. */ }
+
+#if DEBUG
+            stopwatch.Stop();
+            System.Diagnostics.Debug.WriteLine("Traversing \"{0}\" takes {1} ms.", basePath,
+                                               stopwatch.ElapsedMilliseconds);
+#endif
 
             return homeworkMap.Select(r => new HomeworkItem() {
                 Homework = r.Key, WorkingFilesOnly = r.Value

--- a/TeamsAssignmentExplorer/DirAndFileScanner.cs
+++ b/TeamsAssignmentExplorer/DirAndFileScanner.cs
@@ -43,7 +43,7 @@ namespace TeamsAssignmentExplorer
 
         public static List<HomeworkItem> GetHomeworkList(string basePath)
         {
-#if DEBUG 
+#if DEBUG
             var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();
 #endif

--- a/TeamsAssignmentExplorer/DirAndFileScanner.cs
+++ b/TeamsAssignmentExplorer/DirAndFileScanner.cs
@@ -23,11 +23,11 @@ namespace TeamsAssignmentExplorer
         {
             var output = new List<string>();
             string basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            foreach (string orgDir in Directory.GetDirectories(basePath))
+            foreach (string orgDir in Directory.EnumerateDirectories(basePath))
             {
                 try
                 {
-                    foreach (string repoDir in Directory.GetDirectories(orgDir))
+                    foreach (string repoDir in Directory.EnumerateDirectories(orgDir))
                     {
                         if (StringConstants.StudentWorkSuffixes.Any(s => repoDir.EndsWith(s)))
                             output.Add(repoDir);
@@ -52,14 +52,14 @@ namespace TeamsAssignmentExplorer
 
             try
             {
-                foreach (string submittedOrWorkingFilesDir in Directory.GetDirectories(basePath))
+                foreach (string submittedOrWorkingFilesDir in Directory.EnumerateDirectories(basePath))
                 {
-                    foreach (string userDir in Directory.GetDirectories(submittedOrWorkingFilesDir))
+                    foreach (string userDir in Directory.EnumerateDirectories(submittedOrWorkingFilesDir))
                     {
-                        foreach (string homeworkDir in Directory.GetDirectories(userDir))
+                        foreach (string homeworkDir in Directory.EnumerateDirectories(userDir))
                         {
-                            string[] dirs = Directory.GetDirectories(homeworkDir);
-                            bool isWorkingFiles = dirs.Length == 0;
+                            var dirList = Directory.EnumerateDirectories(homeworkDir).GetEnumerator();
+                            bool isWorkingFiles = !dirList.MoveNext();
 
                             if (!homeworkMap.ContainsKey(Path.GetFileName(homeworkDir)))
                                 homeworkMap.Add(Path.GetFileName(homeworkDir), isWorkingFiles);
@@ -85,6 +85,8 @@ namespace TeamsAssignmentExplorer
         public static SubmittedAndWorkingFiles GetSubmittedAndWorkingFiles(string basePath, 
                                                                            string homework)
         {
+            System.Diagnostics.Debug.Assert(homework.Trim() != "");
+
             // Glob [basePath]/Submitted files/[user]/[homework]/Version */*.*
             // and [basePath]/Working files/[user]/[homework]/Version */*.*
             //
@@ -95,14 +97,14 @@ namespace TeamsAssignmentExplorer
             var workingFiles = new List<string>();
             try
             {
-                foreach (string submittedOrWorkingFilesDir in Directory.GetDirectories(basePath))
+                foreach (string submittedOrWorkingFilesDir in Directory.EnumerateDirectories(basePath))
                 {
-                    foreach (string userDir in Directory.GetDirectories(submittedOrWorkingFilesDir))
+                    foreach (string userDir in Directory.EnumerateDirectories(submittedOrWorkingFilesDir))
                     {
                         string hwPath = Path.Combine(userDir, homework);
                         if (!Directory.Exists(hwPath))
                             continue;
-                        foreach (string versionDir in Directory.GetDirectories(hwPath))
+                        foreach (string versionDir in Directory.EnumerateDirectories(hwPath))
                         {
                             var files = Directory.GetFiles(versionDir);
                             Array.Sort(files);

--- a/TeamsAssignmentExplorer/MainWindow.xaml.cs
+++ b/TeamsAssignmentExplorer/MainWindow.xaml.cs
@@ -200,6 +200,7 @@ namespace TeamsAssignmentExplorer
             // not happen.
             // Do not execute update if Homework is nothing.
             if (FormData.Homework.Trim() == "") return;
+            if (FormData.Homework == loadingHomeworkList) return;
             if (FormData.Homework == selectFromDropDown) return;
 
             var allFiles = DirAndFileScanner.GetSubmittedAndWorkingFiles(FormData.Folder,

--- a/TeamsAssignmentExplorer/MainWindow.xaml.cs
+++ b/TeamsAssignmentExplorer/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -18,6 +19,7 @@ namespace TeamsAssignmentExplorer
     /// </summary>
     public partial class MainWindow : Window
     {
+        const string loadingHomeworkList = "(Loading homework list...)";
         const string selectFromDropDown = "(Please select from the drop-down list.)";
 
         public class FileListItem
@@ -144,9 +146,13 @@ namespace TeamsAssignmentExplorer
         }
 
 
-        protected void UpdateHomeworkList()
+        protected async Task UpdateHomeworkList()
         {
-            var list = DirAndFileScanner.GetHomeworkList(FormData.Folder);
+            FormData.Homework = loadingHomeworkList;
+            HomeworkComboBox.IsEnabled = false;
+
+            var list = await Task.Factory.StartNew(
+                () => DirAndFileScanner.GetHomeworkList(FormData.Folder));
             HomeworkList.Clear();
             foreach (var item in list)
             {
@@ -160,6 +166,7 @@ namespace TeamsAssignmentExplorer
             }
 
             FormData.Homework = selectFromDropDown;
+            HomeworkComboBox.IsEnabled = true;
             return;
         }
 
@@ -189,6 +196,12 @@ namespace TeamsAssignmentExplorer
 
         protected void MaybeUpdateFileList()
         {
+            // TODO: investigate FormData.Homework can be empty if Folder is changed. This should
+            // not happen.
+            // Do not execute update if Homework is nothing.
+            if (FormData.Homework.Trim() == "") return;
+            if (FormData.Homework == selectFromDropDown) return;
+
             var allFiles = DirAndFileScanner.GetSubmittedAndWorkingFiles(FormData.Folder,
                                                                          FormData.Homework);
             List<string> files = allFiles.SubmittedFiles;
@@ -221,7 +234,7 @@ namespace TeamsAssignmentExplorer
         protected void FormData_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "Folder")
-                UpdateHomeworkList();
+                _ = UpdateHomeworkList();
             else if (e.PropertyName == "Homework" || e.PropertyName == "ShowWorkingFiles")
                 MaybeUpdateFileList();
         }


### PR DESCRIPTION
- Parallelize GetHomeworkList and GetFolderList.
- Change Get* to Enumerate* to improve performance.
- Bug fix: wrong file list shown when changing Student Work folder.
- Bug fix: program fail to work if Student Work folder end with path separator.